### PR TITLE
feat: update windows to sylixos convert.

### DIFF
--- a/lib/tar.js
+++ b/lib/tar.js
@@ -250,7 +250,8 @@ async function* walkdir (files, options = walkdirDefaults) {
 
   for (const dir of files.map(f => path.join(f)/*normalize file path*/)) {
     const stats = await fsPromises.lstat(dir)
-    stats.name = pathTransform ? pathTransform(dir) : dir
+    const rawName = pathTransform ? pathTransform(dir) : dir
+    stats.name = rawName.split(path.sep).join('/')
 
     if (stats.isFile()) {
       if (stats.size < 1 && options.includeEmptyFile) {


### PR DESCRIPTION
之前ecsc在windows上打包出tar后，在类unix系统上解压会产生分隔符不一致的问题；
这次更新可以windows上打包出的tar在unix下也能正常使用。